### PR TITLE
refactor: allow all NextUI provider props on fragment provider

### DIFF
--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -4,11 +4,8 @@ import { useEffect, useState } from "react";
 import defaultsDeep from "lodash.defaultsdeep";
 import { FragmentUIContext, defaultContext } from "./context";
 
-interface FragmentUIProviderProps {
-  children: React.ReactNode;
-  locale?: NextUIProviderProps['locale'];
-  navigate?: NextUIProviderProps['navigate'];
-  defaults?: FragmentUIContext['defaults']
+interface FragmentUIProviderProps extends NextUIProviderProps {
+  defaults?: FragmentUIContext['defaults'];
 }
 
 export const FragmentUIProvider: React.FC<FragmentUIProviderProps> = ({


### PR DESCRIPTION
Currently it is not possible to pass `className` to `FragmentUIProvider` which this PR will change.
Alternatively we can also just add `className` as prop instead of allowing all NextUI provider props, WDYT @sapkra .