### PR TITLE
fix: copy component type in withFragment

### DIFF
--- a/src/withFragment.tsx
+++ b/src/withFragment.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useContext } from "react";
+import { forwardRef, isValidElement, useContext } from "react";
 import defaultsDeep from "lodash.defaultsdeep";
 import { FragmentUIContext } from "./context";
 
@@ -19,6 +19,10 @@ export function withFragment<C extends React.ComponentType<any>>(Component: C, c
   if ('getCollectionNode' in Component) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (ComponentWithContext as any).getCollectionNode = Component.getCollectionNode;
+  }
+
+  if (isValidElement(ComponentWithContext) && isValidElement(Component)) {
+    ComponentWithContext.type = Component.type;
   }
 
   return ComponentWithContext as unknown as C;


### PR DESCRIPTION
NextUI relies on the component type to select distinct children with [`pickChildren`](https://github.com/nextui-org/nextui/blob/cf0d4e471ec2dd3c2fbebbd58355a821e1aebcf3/packages/utilities/react-rsc-utils/src/children.ts#L15).
An example component where this is used is `BreadCrumbs`.

This PR copies the type of the component wrapped by `withFragment` over  to the wrapper component returned by `withFragment`.