### PR TITLE
feat: add new form section variants

### DIFF
--- a/src/fragments/form/FormSection.stories.tsx
+++ b/src/fragments/form/FormSection.stories.tsx
@@ -49,3 +49,31 @@ export const HorizontalSimple: Story = {
     children: <Switch />,
   },
 };
+
+export const FullWidth: Story = {
+  args: {
+    title: 'Profile',
+    description: 'These are my personal information.',
+    fullWidth: true,
+    children: (
+      <>
+        <Input label="Firstname" />
+        <Input label="Lastname" />
+      </>
+    ),
+  },
+};
+
+export const NoBorder: Story = {
+  args: {
+    title: 'Profile',
+    description: 'These are my personal information.',
+    noBorder: true,
+    children: (
+      <>
+        <Input label="Firstname" />
+        <Input label="Lastname" />
+      </>
+    ),
+  },
+};

--- a/src/fragments/form/FormSection.tsx
+++ b/src/fragments/form/FormSection.tsx
@@ -7,13 +7,15 @@ import { tv } from "@nextui-org/react";
 export interface FormSectionProps {
   children: React.ReactNode;
   title: string;
-  description?: string;
+  description?: string | React.ReactNode;
   direction?: 'vertical' | 'horizontal'
+  fullWidth?: boolean;
+  noBorder?: boolean;
 }
 
 const formSection = tv({
   slots: {
-    base: 'flex gap-4 py-6 border-t-1 border-default-100 max-w-3xl flex-col',
+    base: 'flex gap-4 py-6 flex-col',
     content: 'flex flex-col gap-4 flex-1',
     info: 'flex-1',
     description: 'text-small text-foreground-500',
@@ -25,10 +27,26 @@ const formSection = tv({
         content: 'sm:items-end sm:justify-center',
       },
       vertical: {},
+    },
+    fullWidth: {
+      true: {
+        base: 'w-full',
+      },
+      false: {
+        base: 'max-w-3xl',
+      }
+    },
+    noBorder: {
+      true: {},
+      false: {
+        base: 'border-t-1 border-default-100',
+      }
     }
   },
   defaultVariants: {
     direction: 'vertical',
+    fullWidth: false,
+    noBorder: false,
   },
 });
 


### PR DESCRIPTION
When working with widgets it would be good if the form section grows to the same size as the widget:

Before:

<img width="1464" alt="Screenshot 2024-06-10 at 10 38 41" src="https://github.com/fragment-build/fragment-ui/assets/35739042/9595d91f-cacf-4daa-a1a0-9bee22e54a2e">

After:

<img width="1463" alt="Screenshot 2024-06-10 at 10 39 59" src="https://github.com/fragment-build/fragment-ui/assets/35739042/4fed2d69-83e4-4568-b0d4-373871a79d81">

WDYT?